### PR TITLE
build: To push back changelog, we need a separate user.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         # Adjust tag with desired version if applicable.
         uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_GITHUB_TOKEN }}
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"
           directory: './backend'
@@ -49,7 +49,7 @@ jobs:
         uses: python-semantic-release/publish-action@v10.5.3
         if: steps.release.outputs.released == 'true'
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_GITHUB_TOKEN }}
           tag: ${{ steps.release.outputs.tag }}
           directory: './backend'
 


### PR DESCRIPTION
We can't currently bypass branch protection rules for the default github
app user in github actions. (https://github.com/orgs/community/discussions/13836)

So we need to use the semantic release github user which has been added
to the list of users that can bypass branch protection.
