### PR TITLE
build: Don't create a changelog.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
           github_token: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_GITHUB_TOKEN }}
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"
+          changelog: "false"
           directory: './backend'
 
       - name: Publish | Upload to GitHub Release Assets

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -44,6 +44,3 @@ dependencies = {file = "requirements/base.in"}
 [tool.setuptools.packages.find]
 include = ["sample_plugin*"]
 exclude = ["sample_plugin.tests*"]
-
-[tool.semantic_release.changelog.default_templates]
-changelog_file = "../CHANGELOG.md"


### PR DESCRIPTION
Pushing the changelog back up is not possible because all commits need
to be CLA checked and there's no way to do that with PSR at the moment.
