### PR TITLE
build: Add a default build command.

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -44,3 +44,6 @@ dependencies = {file = "requirements/base.in"}
 [tool.setuptools.packages.find]
 include = ["sample_plugin*"]
 exclude = ["sample_plugin.tests*"]
+
+[tool.semantic_release]
+build_command = "python -m build"


### PR DESCRIPTION
Python semantic release does not build the project by default, just
tags it.  So if we want to publish the project to PyPI we need to add
the build command.
