### PR TITLE
fix: pin pypa/gh-action-pypi-publish to a commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
           path: backend-plugin-sample/dist
 
       - name: Publish to PyPi
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: backend-plugin-sample/dist
           user: __token__
@@ -128,7 +128,7 @@ jobs:
           path: tutor-contrib-sample/dist
 
       - name: Publish to PyPi
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: tutor-contrib-sample/dist
           user: __token__


### PR DESCRIPTION
## Summary

Pin `pypa/gh-action-pypi-publish` to a commit SHA (was `@release/v1`, a floating branch ref), consistent with how every other action in this workflow is already pinned.

## Why

This repo's own dedicated SHA-pinning PR (#53) pinned `actions/checkout`, `python-semantic-release/python-semantic-release`, `python-semantic-release/publish-action`, `actions/upload-artifact`, `actions/download-artifact`, and `actions/setup-node` in this same file -- but missed `pypa/gh-action-pypi-publish@release/v1`. My guess: every other line used a normal `@vX` version tag, which whatever tool/regex drove that sweep would recognize; `release/v1` looks like a branch name rather than that pattern, so it slipped through.

This isn't just a consistency nit. `openedx/xblocks-core`'s real release just failed with `docker: manifest unknown` because `@release/v1` resolved to a commit whose Docker image wasn't published on ghcr.io yet (a race between the branch moving and the image being built) -- see https://github.com/openedx/xblocks-core/actions/runs/29327012856/job/87066591905.

Since this repo is the reference implementation the org-wide "modernize Python tooling" effort copies from (openedx/public-engineering#506), the unpinned ref propagates into every downstream repo that follows this template -- it already did into several of the repos in that effort before this was caught.

For what it's worth, `pypa/gh-action-pypi-publish`'s own README shows `@release/v1` in its usage examples, but the same README's "pro tip" note recommends pinning to a tag or SHA rather than a branch pointer -- there's no upstream guidance suggesting this action is meant to be exempt from normal pinning practice.

## Test plan

- YAML is unchanged apart from the two `uses:` lines; no functional change to the workflow's logic.
- SHA `cef221092ed1bacb1cc03d23a2d87d1d172e277b` is the current tip of `pypa/gh-action-pypi-publish`'s `release/v1` branch (v1.14.0) as of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
